### PR TITLE
Add min attr with value at 0 to the quantity field.

### DIFF
--- a/code/GroupedCartFormChildHooks.php
+++ b/code/GroupedCartFormChildHooks.php
@@ -17,6 +17,7 @@ class GroupedCartFormChildHooks extends DataExtension
 	public function getQuantityField($label = '') {
 		$f = new NumericField("Product[{$this->owner->ID}][Quantity]", $label);
 		$f->setAttribute('type', Config::inst()->get('GroupedCartFormChildHooks', 'quantity_field_type'));
+		$f->setAttribute('min', '0');
 		$f->addExtraClass('grouped-quantity');
 		return $f;
 	}


### PR DESCRIPTION
There isn't a scenario that I can think of where the value in this field would need to be a negative. This is more of a UI quirk when scrolling (down) when the field has the focus state.
